### PR TITLE
Undefined object keys corrupt stack

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -633,21 +633,23 @@ var Twig = (function (Twig) {
                     if (this.options.strict_variables) {
                         throw new Twig.Error("Can't access a key " + key + " on an null or undefined object.");
                     } else {
-                        return null;
+                        value = undefined;
                     }
-                }
-
-                var capitalize = function(value) {return value.substr(0, 1).toUpperCase() + value.substr(1);};
-
-                // Get the variable from the context
-                if (typeof object === 'object' && key in object) {
-                    value = object[key];
-                } else if (object["get"+capitalize(key)] !== undefined) {
-                    value = object["get"+capitalize(key)];
-                } else if (object["is"+capitalize(key)] !== undefined) {
-                    value = object["is"+capitalize(key)];
                 } else {
-                    value = undefined;
+                    var capitalize = function (value) {
+                        return value.substr(0, 1).toUpperCase() + value.substr(1);
+                    };
+
+                    // Get the variable from the context
+                    if (typeof object === 'object' && key in object) {
+                        value = object[key];
+                    } else if (object["get" + capitalize(key)] !== undefined) {
+                        value = object["get" + capitalize(key)];
+                    } else if (object["is" + capitalize(key)] !== undefined) {
+                        value = object["is" + capitalize(key)];
+                    } else {
+                        value = undefined;
+                    }
                 }
                 stack.push(Twig.expression.resolve(value, object, params));
             }

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -302,5 +302,11 @@ describe("Twig.js Expressions ->", function() {
             test_template = twig({data: '{{ {(foo): "value"}.bar }}'});
             test_template.render({foo: 'bar'}).should.equal('value');
         });
+
+        it("should not corrupt the stack when accessing a property of an undefined object", function() {
+            var test_template = twig({data: '{% if true and somethingUndefined.property is not defined %}ok{% endif %}'});
+            var output = test_template.render({});
+            output.should.equal('ok');
+        });
     });
 });


### PR DESCRIPTION
This took a while to track down, but basically, doing the return null; as the original code does ends up in the object for which you are trying to get a property from being removed from the stack, and nothing going back on the stack to replace it. This is bad for chained expressions.